### PR TITLE
Add GitHub Skills activity to signup system

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description

This PR adds the missing GitHub Skills activity to the extracurricular activities signup system, addressing issue #6.

## Changes Made

- Added "GitHub Skills" activity to the activities dictionary in `src/app.py`
- Set schedule: Thursdays, 3:30 PM - 5:00 PM
- Maximum capacity: 25 students
- Description includes mention of GitHub Certifications program for college applications

## Context

The principal announced this partnership with GitHub at the school assembly, but the activity wasn't available on the signup page. This is time-sensitive as registrations close by the end of this week.

## Testing

- [ ] Verify the GitHub Skills activity appears in the activities list on the webpage
- [ ] Confirm students can successfully register for the activity
- [ ] Check that the activity details display correctly

Closes #6